### PR TITLE
Updated hook_drush_help with aditional info

### DIFF
--- a/drush/boilerplate.drush.inc
+++ b/drush/boilerplate.drush.inc
@@ -30,6 +30,12 @@ function boilerplate_drush_command() {
  */
 function boilerplate_drush_help($section) {
   switch ($section) {
+    case 'meta:boilerplate:title':
+      return dt("Boilerplate commands");
+
+    case 'meta:boilerplate:summary':
+      return dt("Interact with the Boilerplate module functionalities.");
+
     case 'drush:boilerplate-hello':
       return dt('Sample Drush command for boilerplate module. It will just greet you, optionally with a name you provided.');
   }


### PR DESCRIPTION
Added integration with the drush help --filter option. To read a discussion about this you can go to [How to integrate the drush help --filter option with your custom module?](http://drupal.stackexchange.com/q/214326/28275) and check the [sandwich example](https://github.com/drush-ops/drush/blob/master/examples/sandwich.drush.inc#L131) inside the drush code.

Now you can use 
drush
drush help --filter
drush --filter=boilerplate

And see a section for your boilerplate commands