### PR TITLE
Implemented the hook_complete

### DIFF
--- a/boilerplate.drush.inc
+++ b/boilerplate.drush.inc
@@ -60,6 +60,7 @@ function boilerplate_hello_command() {
  * Command argument complete callback.
  *
  * Provides argument values for shell completion.
+ * To make this works read https://github.com/drush-ops/drush/blob/master/drush.complete.sh
  *
  * @return array
  *   Array of popular fillings.

--- a/boilerplate.drush.inc
+++ b/boilerplate.drush.inc
@@ -60,7 +60,7 @@ function boilerplate_hello_command() {
  * Command argument complete callback.
  *
  * Provides argument values for shell completion.
- * To make this works read https://github.com/drush-ops/drush/blob/master/drush.complete.sh
+ * To make this works you must execute the first time the command drush init
  *
  * @return array
  *   Array of popular fillings.

--- a/boilerplate.drush.inc
+++ b/boilerplate.drush.inc
@@ -55,3 +55,15 @@ function boilerplate_hello_command() {
     drush_log(dt('Hello there!'), 'success');
   }
 }
+
+/**
+ * Command argument complete callback.
+ *
+ * Provides argument values for shell completion.
+ *
+ * @return array
+ *   Array of popular fillings.
+ */
+function boilerplate_boilerplate_hello_complete() {
+  return array('values' => array('everybody', 'friends', 'Ali', 'Amelie'));
+}


### PR DESCRIPTION
Once you follow the configuration instructions inside https://github.com/drush-ops/drush/blob/master/drush.complete.sh you can do this:

Write the following:
`drush boilerplate-hi eve`
and push tab to autocomplete:
`drush boilerplate-hi everyone`
